### PR TITLE
Fix roman numeral regex

### DIFF
--- a/2_relocate_duplicate_ROMs.py
+++ b/2_relocate_duplicate_ROMs.py
@@ -46,6 +46,8 @@ args.root_dir = os.path.abspath(args.root_dir)
 
 # ——— Helpers for normalization & preferences —————————————————————————
 _ROMAN = {'ix':9,'viii':8,'vii':7,'vi':6,'iv':4,'iii':3,'ii':2,'i':1}
+# compile regex once with longest tokens first for stable matching
+_ROMAN_RE = re.compile(r'\b(' + '|'.join(sorted(_ROMAN, key=len, reverse=True)) + r')\b')
 STOP_WORDS = {'version','special','edition','rev','s','and','the'}
 SEQUEL_TOKENS = set(['part'] + list(_ROMAN.keys()))
 
@@ -59,8 +61,7 @@ def norm(filename):
     s = re.sub(r'[\(\[].*?[\)\]]', '', s)
     s = re.sub(r'^the\s+', '', s)
     s = s.replace('&', ' and ')
-    s = re.sub(r'\b(' + '|'.join(_ROMAN.keys()) + r')\b',
-               lambda m: str(_ROMAN[m.group(1)]), s)
+    s = _ROMAN_RE.sub(lambda m: str(_ROMAN[m.group(1)]), s)
     s = re.sub(r'[^a-z0-9 ]+', ' ', s)
     return re.sub(r'\s+', ' ', s).strip()
 

--- a/4_sales_to_gamelist.py
+++ b/4_sales_to_gamelist.py
@@ -12,6 +12,7 @@ from rapidfuzz import process, fuzz
 
 # ——— Title normalization helper —————————————————————————————————
 _ROMAN = {'ix':9,'viii':8,'vii':7,'vi':6,'iv':4,'iii':3,'ii':2,'i':1}
+_ROMAN_RE = re.compile(r'\b(' + '|'.join(sorted(_ROMAN, key=len, reverse=True)) + r')\b')
 
 def norm(title):
     s = unicodedata.normalize('NFKD', str(title))
@@ -20,8 +21,7 @@ def norm(title):
     s = re.sub(r'[\(\[].*?[\)\]]', '', s)
     s = re.sub(r'^the\s+', '', s)
     s = s.replace('&', ' and ')
-    s = re.sub(r'\b(' + '|'.join(_ROMAN.keys()) + r')\b',
-               lambda m: str(_ROMAN[m.group(1)]), s)
+    s = _ROMAN_RE.sub(lambda m: str(_ROMAN[m.group(1)]), s)
     s = re.sub(r'[^a-z0-9 ]+', ' ', s)
     return re.sub(r'\s+', ' ', s).strip()
 

--- a/5_make_links_for_unmatched_ROMs.py
+++ b/5_make_links_for_unmatched_ROMs.py
@@ -46,6 +46,7 @@ def setup_tab_completion():
 
 # ——— Title normalization helper ———————————————————————————————————
 _ROMAN = {'ix':9,'viii':8,'vii':7,'vi':6,'iv':4,'iii':3,'ii':2,'i':1}
+_ROMAN_RE = re.compile(r'\b(' + '|'.join(sorted(_ROMAN, key=len, reverse=True)) + r')\b')
 
 def norm(title):
     s = unicodedata.normalize('NFKD', str(title))
@@ -54,8 +55,7 @@ def norm(title):
     s = re.sub(r'[\(\[].*?[\)\]]', '', s)
     s = re.sub(r'^the\s+', '', s)
     s = s.replace('&', ' and ')
-    s = re.sub(r'\b(' + '|'.join(_ROMAN.keys()) + r')\b',
-               lambda m: str(_ROMAN[m.group(1)]), s)
+    s = _ROMAN_RE.sub(lambda m: str(_ROMAN[m.group(1)]), s)
     s = re.sub(r'[^a-z0-9 ]+', ' ', s)
     return re.sub(r'\s+', ' ', s).strip()
 


### PR DESCRIPTION
## Summary
- compile a reusable roman numeral regex
- use it in normalization routines for duplicate detection, gamelist sales integration and link generation

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68718eadc484833097d93950db8f608e