### PR TITLE
Improve manual matching for multi-disc games

### DIFF
--- a/5_make_links_for_unmatched_ROMs.py
+++ b/5_make_links_for_unmatched_ROMs.py
@@ -415,8 +415,7 @@ def main():
                         if idx_choice < len(options):
                             best_keys, score = options[idx_choice]
                             if score < threshold:
-                                print(f"  [SKIP] {game} (score below threshold: {score})")
-                                best_keys = None
+                                print(f"  Selected option below threshold ({score} < {threshold})")
                         break
                     if choice == '':
                         best_keys = None


### PR DESCRIPTION
## Summary
- allow manual selections in `5_make_links_for_unmatched_ROMs.py` even when the fuzzy score is below the threshold

## Testing
- `python3 -m py_compile 5_make_links_for_unmatched_ROMs.py 6_download_links_of_unmatched_ROMs.py list_rom_filenames.py 2_relocate_duplicate_ROMs.py 3_m3u_multidisc.py 4_sales_to_gamelist.py scrape_platform_urls.py`

------
https://chatgpt.com/codex/tasks/task_e_68729dfed50083308d64acf7535390a3