### PR TITLE
Handle multi-disc games in manual mode

### DIFF
--- a/6_download_links_of_unmatched_ROMs.py
+++ b/6_download_links_of_unmatched_ROMs.py
@@ -92,19 +92,24 @@ def main():
                 sys.exit(1)
 
         for row in reader:
-            url = row['URL'].strip()
             platform = row['Directory'].strip() or row['Platform'].strip()
-            title = row['Matched_Title'].strip()
-            if not url:
-                continue
-            # determine output directory
-            out_dir = os.path.join(NEW_ROOT, platform)
-            os.makedirs(out_dir, exist_ok=True)
-            # prepare aria2 entry
-            entry = url + '\n'
-            entry += f"  out={title}\n"
-            entry += f"  dir={out_dir}\n"
-            entries.append(entry)
+            for idx in range(1, 100):
+                url_col = 'URL' if idx == 1 else f'URL_{idx}'
+                title_col = 'Matched_Title' if idx == 1 else f'Matched_Title_{idx}'
+                if url_col not in row:
+                    break
+                url = row[url_col].strip()
+                if not url:
+                    continue
+                title = row.get(title_col, row.get('Matched_Title', '')).strip()
+                if not title:
+                    title = os.path.basename(url)
+                out_dir = os.path.join(NEW_ROOT, platform)
+                os.makedirs(out_dir, exist_ok=True)
+                entry = url + '\n'
+                entry += f"  out={title}\n"
+                entry += f"  dir={out_dir}\n"
+                entries.append(entry)
 
     if not entries:
         print("No valid download entries found in CSV. Exiting.")


### PR DESCRIPTION
## Summary
- detect when a disc is chosen in script 5 and gather all matching discs
- store multi-disc URLs in a single CSV row with numbered columns
- allow download script to process URL_2/Matched_Title_2 etc.
- fill missing values when writing CSV

## Testing
- `python3 -m py_compile 5_make_links_for_unmatched_ROMs.py 6_download_links_of_unmatched_ROMs.py`

------
https://chatgpt.com/codex/tasks/task_e_6872a056aa148330b1f62b1d2bc056e8