### PR TITLE
Simplify multi-disc export

### DIFF
--- a/5_make_links_for_unmatched_ROMs.py
+++ b/5_make_links_for_unmatched_ROMs.py
@@ -428,7 +428,7 @@ def main():
                     continue
                 selected_keys = best_keys
                 # If a disc was chosen, gather any additional discs for the same
-                # game so they can be stored in a single CSV row.
+                # game so they can all be stored as separate rows.
                 selected_names = [file_names[k] for k in selected_keys]
                 if any(DISC_RE.search(n) for n in selected_names):
                     base = norm(remove_disc(selected_names[0]))
@@ -447,40 +447,29 @@ def main():
                     continue
                 selected_keys = group_map.get(norm(remove_disc(file_names[best_key])), [best_key])
 
-            if manual_mode and len(selected_keys) > 1:
-                row_data = {
+            # remove duplicate disc entries while preserving order
+            uniq_keys = []
+            seen = set()
+            for k in selected_keys:
+                if k not in seen:
+                    uniq_keys.append(k)
+                    seen.add(k)
+
+            for k in uniq_keys:
+                href = file_map[k]
+                download_url = urljoin(url, href)
+                matched_title = unquote(href)
+
+                rows.append({
                     'Search_Term': game,
                     'Platform': ds_code,
                     'Directory': out_dir_name,
+                    'Matched_Title': matched_title,
                     'Score': score,
                     'Global_Sales': sales,
-                }
-                for idx, k in enumerate(selected_keys, start=1):
-                    href = file_map[k]
-                    download_url = urljoin(url, href)
-                    matched_title = unquote(href)
-                    title_col = 'Matched_Title' if idx == 1 else f'Matched_Title_{idx}'
-                    url_col = 'URL' if idx == 1 else f'URL_{idx}'
-                    row_data[title_col] = matched_title
-                    row_data[url_col] = download_url
-                    print(f"  Matched {game} -> {matched_title} (score {score}, sales {sales})")
-                rows.append(row_data)
-            else:
-                for k in selected_keys:
-                    href = file_map[k]
-                    download_url = urljoin(url, href)
-                    matched_title = unquote(href)
-
-                    rows.append({
-                        'Search_Term': game,
-                        'Platform': ds_code,
-                        'Directory': out_dir_name,
-                        'Matched_Title': matched_title,
-                        'Score': score,
-                        'Global_Sales': sales,
-                        'URL': download_url
-                    })
-                    print(f"  Matched {game} -> {matched_title} (score {score}, sales {sales})")
+                    'URL': download_url
+                })
+                print(f"  Matched {game} -> {matched_title} (score {score}, sales {sales})")
 
     # write outputs
     df_out = pd.DataFrame(rows)


### PR DESCRIPTION
## Summary
- generate a row per disc rather than using extra columns
- deduplicate discs while preserving order

## Testing
- `python3 -m py_compile 5_make_links_for_unmatched_ROMs.py`


------
https://chatgpt.com/codex/tasks/task_e_6872a341ff1883308d71f54a145ec687