### PR TITLE
Fix extras iteration in download script

### DIFF
--- a/6_download_links_of_unmatched_ROMs.py
+++ b/6_download_links_of_unmatched_ROMs.py
@@ -77,7 +77,7 @@ def find_extra_discs(url: str, filename: str, max_discs: int = 8):
     """
     m = DISC_RE.search(filename)
     if not m:
-        return
+        return []
 
     num_str = m.group('num')
     try:
@@ -85,7 +85,7 @@ def find_extra_discs(url: str, filename: str, max_discs: int = 8):
     except ValueError:
         disc_num = ROMAN_TO_INT.get(num_str.lower(), 0)
     if disc_num <= 0 or disc_num >= max_discs:
-        return
+        return []
 
     prefix = filename[:m.start('num')]
     suffix = filename[m.end('num'):]
@@ -198,15 +198,15 @@ def main():
                     print(f"Multi-disc detected for '{title}':")
                     for _, etitle in extras:
                         print(f"  -> {etitle}")
-                for extra_url, extra_title in extras:
-                    key = (extra_url, extra_title, out_dir)
-                    if key in seen:
-                        continue
-                    extra_entry = extra_url + '\n'
-                    extra_entry += f"  out={extra_title}\n"
-                    extra_entry += f"  dir={out_dir}\n"
-                    entries.append(extra_entry)
-                    seen.add(key)
+                    for extra_url, extra_title in extras:
+                        key = (extra_url, extra_title, out_dir)
+                        if key in seen:
+                            continue
+                        extra_entry = extra_url + '\n'
+                        extra_entry += f"  out={extra_title}\n"
+                        extra_entry += f"  dir={out_dir}\n"
+                        entries.append(extra_entry)
+                        seen.add(key)
 
     if not entries:
         print("No valid download entries found in CSV. Exiting.")


### PR DESCRIPTION
## Summary
- fix multi-disc lookup to return an empty list when nothing is found
- only iterate over extra discs when they exist

## Testing
- `python -m py_compile 6_download_links_of_unmatched_ROMs.py`
- `python 6_download_links_of_unmatched_ROMs.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6872cb7527d883309b2381217a821a3b