### PR TITLE
Update batch install script to use pyreadline3

### DIFF
--- a/1_first_install_prerequisites.bat
+++ b/1_first_install_prerequisites.bat
@@ -23,7 +23,8 @@ python -m pip install --upgrade pip
 REM 3. Install required packages
 echo.
 echo Installing required Python packages...
-python -m pip install rapidfuzz pandas pyreadline
+REM Replaced pyreadline with pyreadline3 for Python 3 compatibility
+python -m pip install rapidfuzz pandas pyreadline3
 
 if ERRORLEVEL 1 (
     echo.


### PR DESCRIPTION
## Summary
- update the prereq install batch file to install `pyreadline3` instead of `pyreadline`
- note the change in a comment for clarity

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6872d47d7a108330ae58967246153d26