### PR TITLE
Add optional filter for Wii games without controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ script asks whether to load the newest existing snapshot or create a
 fresh one.  Before fuzzy searches such as duplicate detection or sales
 matching, you will be prompted for a match threshold.
 
+When adding games, you may optionally exclude Wii titles that do not list controller support in `sales_2019.csv`.
 Helper files (`aria2c.exe`, `chdman.exe`, `sales_2019.csv`,
 `platforms.csv`) must reside in the `wizardry/` folder.
 When a snapshot is created, a `rom_filenames.txt` file listing all


### PR DESCRIPTION
## Summary
- add `filter_wii_no_controller` helper in `rom_wizard.py`
- ask whether to exclude Wii games lacking controller support when adding games
- document the new option in README

## Testing
- `python -m py_compile rom_wizard.py`

------
https://chatgpt.com/codex/tasks/task_e_688bb375f4e88330af65236421ebe390