### PR TITLE
Include all ROM directories in platform mapping

### DIFF
--- a/wizardry/platforms.csv
+++ b/wizardry/platforms.csv
@@ -12,7 +12,7 @@ GEN,megadrive,https://myrient.erista.me/files/No-Intro/Sega%20-%20Mega%20Drive%2
 GG,gamegear,https://myrient.erista.me/files/No-Intro/Sega%20-%20Game%20Gear/,FALSE
 N64,n64,https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%2064%20%28BigEndian%29/,FALSE
 NES,nes,https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%20Entertainment%20System%20%28Headered%29/,FALSE
-NG,neogeo,,TRUE
+NG,neogeo,,FALSE
 PC,pc,,TRUE
 PCFX,pcfx,,TRUE
 ports,ports,,TRUE
@@ -32,3 +32,6 @@ WiiU,wiiu,https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Wii%20U%20%28D
 X360,xbox360,,TRUE
 XB,xbox,https://myrient.erista.me/files/Redump/Microsoft%20-%20Xbox/,FALSE
 XOne,xboxone,,TRUE
+ATARIST,atarist,,FALSE
+MAME,mame,,FALSE
+MASTERSYSTEM,mastersystem,,FALSE


### PR DESCRIPTION
## Summary
- Automatically add any ROM library folders missing from `platforms.csv` so every `/roms` directory is represented.
- Skip platforms with no ROMs or flagged `ignore` during snapshot creation and sales matching.
- Respect ignore flags and empty directories when detecting duplicates and generating playlists.
- Restore platform entries for Atari ST, MAME, Master System, and Neo Geo.

## Testing
- `python -m py_compile rom_wizard.py list_rom_filenames.py scrape_platform_urls.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e322c0e083309f6d2b64b9b6ba08